### PR TITLE
Validation bugfix - do not run phone validation for empty strings

### DIFF
--- a/ng-intl-tel-input.directive.js
+++ b/ng-intl-tel-input.directive.js
@@ -18,7 +18,12 @@ angular.module('ngIntlTelInput')
           ngIntlTelInput.init(elm);
           // Validation.
           ctrl.$validators.ngIntlTelInput = function (value) {
-            return elm.intlTelInput("isValidNumber");
+              // if phone number is deleted / empty do not run phone number validation 
+              if (value || elm[0].value.length > 1) {
+                  return elm.intlTelInput("isValidNumber");
+              } else {
+                  return true;
+              }
           };
           // Set model value to valid, formatted version.
           ctrl.$parsers.push(function (value) {


### PR DESCRIPTION
This is also applicable in case where there was previously phone number and user wants to delete it. Previously he couldn't - empty string (or +1) would be run through phone validation and $valid would be set to false.

See this example:

![01](https://cloud.githubusercontent.com/assets/5191402/9419030/dbcefa5e-481d-11e5-9f01-a3560abf0b7d.png)

![02](https://cloud.githubusercontent.com/assets/5191402/9419031/de0cd840-481d-11e5-93e8-c6580b306573.png)
