### PR TITLE
Correct module path for webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ng-intl-tel-input",
   "version": "1.4.0",
   "description": "AngularJS directive implementing intl-tel-input (https://github.com/Bluefieldscom/intl-tel-input)",
-  "main": "ng-intl-tel-input.directive.js",
+  "main": "dist/ng-intl-tel-input.js",
   "scripts": {
     "test": "npm run jshint && npm run karma",
     "build": "npm run concat && npm run uglify",


### PR DESCRIPTION
Hey, thanks for this module. Having some issues using it with Webpack due to the main entry in package.json which I have updated here. Illustrated example of the problem below.

```javascript
import 'ng-intl-tel-input/dist/ng-intl-tel-input'; // current
import 'ng-intl-tel-input'; // desired
```