### PR TITLE
Add support for intlTelInput v9+ - initialCountry vs defaultCountry

### DIFF
--- a/dist/ng-intl-tel-input.js
+++ b/dist/ng-intl-tel-input.js
@@ -39,6 +39,7 @@ angular.module('ngIntlTelInput')
           // Override default country.
           if (attr.defaultCountry) {
             ngIntlTelInput.set({defaultCountry: attr.defaultCountry});
+            ngIntlTelInput.set({initialCountry: attr.defaultCountry});
           }
           // Initialize.
           ngIntlTelInput.init(elm);

--- a/ng-intl-tel-input.directive.js
+++ b/ng-intl-tel-input.directive.js
@@ -13,6 +13,7 @@ angular.module('ngIntlTelInput')
           // Override default country.
           if (attr.defaultCountry) {
             ngIntlTelInput.set({defaultCountry: attr.defaultCountry});
+            ngIntlTelInput.set({initialCountry: attr.defaultCountry});
           }
           // Initialize.
           ngIntlTelInput.init(elm);


### PR DESCRIPTION
The 9+ versions of intlTelInput use initialCountry instead of defaultCountry (although no errors are thrown for passing the incorrect param - it just doesn't work.  

This change should make ng-intl-tel-input compatible with both the 8 and 9 versions.