### PR TITLE
Format number as correct intertational phone number

### DIFF
--- a/ng-intl-tel-input.directive.js
+++ b/ng-intl-tel-input.directive.js
@@ -47,7 +47,7 @@ angular.module('ngIntlTelInput')
           };
           // Set model value to valid, formatted version.
           ctrl.$parsers.push(function (value) {
-            return elm.intlTelInput('getNumber').replace(/[^\d]/, '');
+            return elm.intlTelInput('getNumber');
           });
           // Set input value to model value and trigger evaluation.
           ctrl.$formatters.push(function (value) {

--- a/ng-intl-tel-input.directive.spec.js
+++ b/ng-intl-tel-input.directive.spec.js
@@ -78,13 +78,13 @@ describe('ng-intl-tel-input', function () {
   it('should set the model value to the full phone number with dial code', function () {
     angular.element(element).val('2103128425').trigger('input');
     $scope.$digest();
-    expect($scope.model.tel).toEqual('12103128425');
+    expect($scope.model.tel).toEqual('+12103128425');
   });
 
   it('should set the model value to the full phone number with dial code and plus sign prefix', function () {
     angular.element(element).val('+12103128425').trigger('input');
     $scope.$digest();
-    expect($scope.model.tel).toEqual('12103128425');
+    expect($scope.model.tel).toEqual('+12103128425');
   });
 
   it('should not set the model value when invalid', function () {


### PR DESCRIPTION
Correct international phone number starts with + as without + sign it could be treated not as country calling code, but as dial out code.

https://en.wikipedia.org/wiki/List_of_country_calling_codes
https://en.wikipedia.org/wiki/List_of_international_call_prefixes

Replaces #57 