### PR TITLE
feat(travis): update node versions per LTS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: node_js
 node_js:
-  - "0.12"
-  - "0.11"
-  - "0.10"
   - "iojs"
+  - "0.12"
+  - "4"
+  - "5"
+  - "6"
 install:
   - "npm install"
   - "./node_modules/bower/bin/bower install"


### PR DESCRIPTION
This PR updates the TravisCI build file to use NodeJS versions 0.12, 4, 5, and 6.

See: https://github.com/nodejs/LTS/tree/75bd36a060be3b965e696bc0c53f799089ad0f52