### PR TITLE
added data-ignore-validation attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,3 +79,12 @@ This attribute allows run-time setting of the default country.
 ```html
 <input type="text" ng-model="model.tel" ng-intl-tel-input data-initial-country="gb">
 ```
+
+#### data-ignore-validation attribute
+
+This attribute allows to bypass default phone number format validation.
+
+```html
+<input type="text" ng-model="model.tel" ng-intl-tel-input data-ignore-validation="true">
+```
+

--- a/ng-intl-tel-input.directive.js
+++ b/ng-intl-tel-input.directive.js
@@ -4,6 +4,9 @@ angular.module('ngIntlTelInput')
       return {
         restrict: 'A',
         require: 'ngModel',
+        scope: {
+          ignoreValidation: "="
+        },
         link: function (scope, elm, attr, ctrl) {
           // Warning for bad directive usage.
           if ((!!attr.type && (attr.type !== 'text' && attr.type !== 'tel')) || elm[0].tagName !== 'INPUT') {
@@ -36,15 +39,18 @@ angular.module('ngIntlTelInput')
             angular.element($window).on('countrychange', handleCountryChange);
             scope.$on('$destroy', cleanUp);
           }
-          // Validation.
-          ctrl.$validators.ngIntlTelInput = function (value) {
-            // if phone number is deleted / empty do not run phone number validation
-            if (value || elm[0].value.length > 0) {
+          // If ignoreValidation is false, that is don't ignore the validation, only then validate.
+          if (!scope.ignoreValidation) {
+            // Validation.
+            ctrl.$validators.ngIntlTelInput = function (value) {
+              // if phone number is deleted / empty do not run phone number validation
+              if (value || elm[0].value.length > 0) {
                 return elm.intlTelInput('isValidNumber');
-            } else {
+              } else {
                 return true;
+              }
             }
-          };
+          }
           // Set model value to valid, formatted version.
           ctrl.$parsers.push(function (value) {
             return elm.intlTelInput('getNumber');


### PR DESCRIPTION
There could be a scenario where one would not want to validate the phone number being entered, which by default the directive does. With this directive one can bypass the validation. The attribute would only work if the value "true" is passed to the attribute. if the attribute is not added to the input field or any other value is passed in the attribute , it will work as before.
ref issue# https://github.com/hodgepodgers/ng-intl-tel-input/issues/110